### PR TITLE
Fix error in start script

### DIFF
--- a/bin/hyperion.init.sh
+++ b/bin/hyperion.init.sh
@@ -7,22 +7,27 @@ DAEMON=hyperiond
 DAEMONOPTS="/etc/hyperion.config.json"
 DAEMON_PATH="/usr/bin"
 
-NAME=$DEAMON
+NAME=$DAEMON
 DESC="Hyperion ambilight server"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-
 case "$1" in
 start)
-	printf "%-50s" "Starting $NAME..."
-	cd $DAEMON_PATH
-	PID=`$DAEMON $DAEMONOPTS > /dev/null 2>&1 & echo $!`
-	#echo "Saving PID" $PID " to " $PIDFILE
-        if [ -z $PID ]; then
-            printf "%s\n" "Fail"
+        if [ $(pgrep -l $NAME |wc -l) = 1 ]
+        then
+                printf  "%-50s\n" "Already running..."
+                exit 1
         else
-            echo $PID > $PIDFILE
-            printf "%s\n" "Ok"
+                printf "%-50s" "Starting $NAME..."
+                cd $DAEMON_PATH
+                PID=`$DAEMON $DAEMONOPTS > /dev/null 2>&1 & echo $!`
+                #echo "Saving PID" $PID " to " $PIDFILE
+                if [ -z $PID ]; then
+                    printf "%s\n" "Fail"
+                else
+                    echo $PID > $PIDFILE
+                    printf "%s\n" "Ok"
+                fi
         fi
 ;;
 status)
@@ -39,24 +44,31 @@ status)
         fi
 ;;
 stop)
-        printf "%-50s" "Stopping $NAME"
-            PID=`cat $PIDFILE`
-            cd $DAEMON_PATH
-        if [ -f $PIDFILE ]; then
-            kill -HUP $PID
-            printf "%s\n" "Ok"
-            rm -f $PIDFILE
+        if [ -f $PIDFILE ]
+        then
+                printf "%-50s" "Stopping $NAME"
+                    PID=`cat $PIDFILE`
+                    cd $DAEMON_PATH
+                if [ -f $PIDFILE ]; then
+                    kill -HUP $PID
+                    printf "%s\n" "Ok"
+                    rm -f $PIDFILE
+                else
+                    printf "%s\n" "pidfile not found"
+                fi
         else
-            printf "%s\n" "pidfile not found"
+                printf "%-50s\n" "No PID file $NAME not running?"
         fi
 ;;
 
 restart)
-  	$0 stop
-  	$0 start
+        $0 stop
+        $0 start
 ;;
 
 *)
         echo "Usage: $0 {status|start|stop|restart}"
         exit 1
 esac
+
+exit 0


### PR DESCRIPTION
1) fixed spelling error leading to empty PID file name (DAEMON vs DEAMON)
2) fixed error causing wrong PID in PID file (if process was already running => stop not working)
3) added check if PID file exists, before stop is executed (prevent file not found message)

=> I tried to keep the stye of the script ...
