### PR TITLE
fixed assembler instructions to work without optimization

### DIFF
--- a/libsrc/leddevice/LedDeviceWS2812b.cpp
+++ b/libsrc/leddevice/LedDeviceWS2812b.cpp
@@ -268,7 +268,7 @@ LedDeviceWS2812b::LedDeviceWS2812b() :
 static inline __attribute__((always_inline)) uint32_t arm_ror_imm(uint32_t v, uint32_t sh)
 {
 	uint32_t d;
-	asm ("ROR %[Rd], %[Rm], %[Is]" : [Rd] "=r" (d) : [Rm] "r" (v), [Is] "i" (sh));
+	asm ("ROR %[Rd], %[Rm], %[Is]" : [Rd] "=r" (d) : [Rm] "r" (v), [Is] "r" (sh));
 	return d;
 }
 
@@ -278,7 +278,7 @@ static inline __attribute__((always_inline)) uint32_t arm_ror_imm_add_on_carry(u
 	  uint32_t d;
 	  asm ("RORS %[Rd], %[Rm], %[Is]\n\t"
 		   "ADDCS %[Rd1], %[Rd1], #1"
-			  : [Rd] "=r" (d), [Rd1] "+r" (inc): [Rm] "r" (v), [Is] "i" (sh));
+			  : [Rd] "=r" (d), [Rd1] "+r" (inc): [Rm] "r" (v), [Is] "r" (sh));
 	  return d;
 }
 


### PR DESCRIPTION
According to http://infocenter.arm.com/help/topic/com.arm.doc.dui0068b/BABEHCFA.html there is no immediate option. (Tested on RaspberryPi B+, compiles and works)
