### PR TITLE
AtmoOrb device - removed skip same color change

### DIFF
--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -58,12 +58,6 @@ int LedDeviceAtmoOrb::write(const std::vector <ColorRgb> &ledValues) {
         int lastGreen = lastColorGreenMap[idx];
         int lastBlue = lastColorBlueMap[idx];
 
-        // If last colors send are identical than last send return
-        if(lastRed == color.red && lastGreen == color.green && lastBlue == color.blue)
-        {
-            return 0;
-        }
-
         // If color difference is higher than skipSmoothingDiff than we skip Orb smoothing (if enabled) and send it right away
         if ((skipSmoothingDiff != 0 && useOrbSmoothing) && (abs(color.red - lastRed) >= skipSmoothingDiff || abs(color.blue - lastBlue) >= skipSmoothingDiff ||
                 abs(color.green - lastGreen) >= skipSmoothingDiff))


### PR DESCRIPTION
**1.** Tell us something about your changes.

This reverts the recent change for the AtmoOrb device to skip colors if identical to last send, reason is that in some cases UDP packets might get lost over WiFi which will result in smoothing being off.
This is most noticeably on turn off / clear LED events where it might miss it and leave the Orbs on with the last colors.


