### PR TITLE
Kodi video checker bugifx

### DIFF
--- a/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
+++ b/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
@@ -6,7 +6,7 @@
 #include <xbmcvideochecker/XBMCVideoChecker.h>
 
 // Request player example:
-// {"id":666,"jsonrpc":"2.0","method":"Player.GetActivePlayers"}
+// {"jsonrpc":"2.0","method":"Player.GetActivePlayers", "id":666}
 // {"id":666,"jsonrpc":"2.0","result":[{"playerid":1,"type":"video"}]}
 
 // Request playing item example:

--- a/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
+++ b/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
@@ -25,7 +25,7 @@ XBMCVideoChecker::XBMCVideoChecker(const std::string & address, uint16_t port, b
 	QObject(),
 	_address(QString::fromStdString(address)),
 	_port(port),
-	_activePlayerRequest(R"({"id":666,"jsonrpc":"2.0","method":"Player.GetActivePlayers"})"),
+	_activePlayerRequest(R"({"jsonrpc":"2.0","method":"Player.GetActivePlayers", "id":666})"),
 	_currentPlayingItemRequest(R"({"id":667,"jsonrpc":"2.0","method":"Player.GetItem","params":{"playerid":%1,"properties":["file"]}})"),
 	_checkScreensaverRequest(R"({"id":668,"jsonrpc":"2.0","method":"XBMC.GetInfoBooleans","params":{"booleans":["System.ScreenSaverActive"]}})"),
 	_getStereoscopicMode(R"({"jsonrpc":"2.0","method":"GUI.GetProperties","params":{"properties":["stereoscopicmode"]},"id":669})"),


### PR DESCRIPTION
**1.** Tell us something about your changes.

Kodi video checker patch to make it compliant with their recent JSON RPC API specs:

http://kodi.wiki/view/JSON-RPC_API/v6

ID should be listed last as otherwise this error will occur:

`Kodi Message: {"error":{"code":-32601,"message":"Method not found."},"id":666,"jsonrpc":"2.0"}`

For reference:

https://hyperion-project.org/threads/kodicheck-picture-modus-bad-detection-rate.90

