### PR TITLE
build script optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,12 @@ if(ENABLE_OSX AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and osx grabber cannot be used at the same time")
 endif(ENABLE_OSX AND ENABLE_DISPMANX)
 
-option(ENABLE_SYSTEM_INSTALL "enables make install" OFF)
-message(STATUS "ENABLE_SYSTEM_INSTALL = " ${ENABLE_SYSTEM_INSTALL})
-
+if (DEFINED INSTALL_PREFIX)
+	SET( ENABLE_SYSTEM_INSTALL ON)
+	SET( CMAKE_INSTALL_PREFIX "${INSTALL_PREFIX}" )
+else()
+	SET(ENABLE_SYSTEM_INSTALL OFF)
+endif()
 
 SET ( PROTOBUF_INSTALL_BIN_DIR ${CMAKE_BINARY_DIR}/proto )
 SET ( PROTOBUF_INSTALL_LIB_DIR ${CMAKE_BINARY_DIR}/proto )
@@ -88,15 +91,15 @@ include_directories("${PROJECT_BINARY_DIR}")
 if(ENABLE_QT5)
 	ADD_DEFINITIONS ( -DENABLE_QT5 )
 	#find_package(Qt5Widgets)
-else(ENABLE_QT5)
+else()
 	# Add specific cmake modules to find qt4 (default version finds first available QT which might not be qt4)
 	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/qt4)
-endif(ENABLE_QT5)
+endif()
 
 # Define the global output path of binaries
 SET(LIBRARY_OUTPUT_PATH    ${PROJECT_BINARY_DIR}/lib)
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-
+SET(DEPLOY_DIR "${CMAKE_SOURCE_DIR}/deploy/hyperion" )
 file(MAKE_DIRECTORY ${LIBRARY_OUTPUT_PATH})
 file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
 
@@ -116,10 +119,10 @@ if(ENABLE_QT5)
 	find_package(Qt5 COMPONENTS Core Gui Widgets Network REQUIRED)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}    ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 #	set(CMAKE_CXX_FLAGS "-fPIC")
-else(ENABLE_QT5)
+else()
 	# Configure the use of QT4
 	find_package(Qt4 COMPONENTS QtCore QtNetwork QtGui REQUIRED QUIET)
-endif(ENABLE_QT5)
+endif()
 
 #add libusb and pthreads
 find_package(libusb-1.0 REQUIRED)
@@ -127,10 +130,10 @@ find_package(Threads REQUIRED)
 if(ENABLE_QT5)
 	#include(${QT_USE_FILE})
 	add_definitions(${QT_DEFINITIONS})
-else(ENABLE_QT5)
+else()
 	include(${QT_USE_FILE})
 	add_definitions(${QT_DEFINITIONS})
-endif(ENABLE_QT5)
+endif()
 
 # TODO[TvdZ]: This linking directory should only be added if we are cross compiling
 if(NOT APPLE)
@@ -151,8 +154,7 @@ add_subdirectory(libsrc)
 add_subdirectory(src)
 if (ENABLE_TESTS)
 	add_subdirectory(test)
-endif (ENABLE_TESTS)
-
+endif ()
 
 # Add the doxygen generation directory
 add_subdirectory(doc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,47 @@
 # Define the main-project name
-project(Hyperion)
+project(hyperiond)
 
 # define the minimum cmake version (as required by cmake)
 cmake_minimum_required(VERSION 2.8)
 
 #set(CMAKE_TOOLCHAIN_FILE /opt/raspberrypi/Toolchain-RaspberryPi.cmake)
 
+SET ( DEFAULT_AMLOGIC    OFF )
+SET ( DEFAULT_DISPMANX   OFF )
+SET ( DEFAULT_FB         OFF )
+SET ( DEFAULT_OSX        OFF )
+SET ( DEFAULT_X11        OFF )
+SET ( DEFAULT_WS2812BPWM OFF )
+SET ( DEFAULT_WS281XPWM  OFF )
+
+if (APPLE)
+	SET ( DEFAULT_OSX ON )
+else ()
+	if ( ${PLATFORM} STREQUAL "rpi" )
+		SET ( DEFAULT_DISPMANX   ON )
+		SET ( DEFAULT_WS2812BPWM ON )
+		SET ( DEFAULT_WS281XPWM  ON )
+	elseif ( ${PLATFORM} STREQUAL "wetek" )
+		SET ( DEFAULT_AMLOGIC    ON )
+		SET ( DEFAULT_FB         ON )
+	elseif ( ${PLATFORM} STREQUAL "x86" )
+		SET ( DEFAULT_X11        ON )
+	elseif ( ${PLATFORM} STREQUAL "imx6" )
+		SET ( DEFAULT_FB         ON )
+	endif()
+endif ()
+
 # set the build options
-option(ENABLE_AMLOGIC "Enable the AMLOGIC video grabber" OFF)
+option(ENABLE_AMLOGIC "Enable the AMLOGIC video grabber" ${DEFAULT_AMLOGIC} )
 message(STATUS "ENABLE_AMLOGIC = " ${ENABLE_AMLOGIC})
 
-option(ENABLE_DISPMANX "Enable the RPi dispmanx grabber" ON)
+option(ENABLE_DISPMANX "Enable the RPi dispmanx grabber" ${DEFAULT_DISPMANX} )
 message(STATUS "ENABLE_DISPMANX = " ${ENABLE_DISPMANX})
 
-option(ENABLE_FB "Enable the framebuffer grabber" OFF)
+option(ENABLE_FB "Enable the framebuffer grabber" ${DEFAULT_FB} )
 message(STATUS "ENABLE_FB = " ${ENABLE_FB})
 
-option(ENABLE_OSX "Enable the osx grabber" OFF)
+option(ENABLE_OSX "Enable the osx grabber" ${DEFAULT_OSX} )
 message(STATUS "ENABLE_OSX = " ${ENABLE_OSX})
 
 option(ENABLE_PROTOBUF "Enable PROTOBUF server" ON)
@@ -31,13 +56,13 @@ message(STATUS "ENABLE_TINKERFORGE = " ${ENABLE_TINKERFORGE})
 option(ENABLE_V4L2 "Enable the V4L2 grabber" ON)
 message(STATUS "ENABLE_V4L2 = " ${ENABLE_V4L2})
 
-option(ENABLE_WS2812BPWM   "Enable the WS2812b-PWM device" OFF)
+option(ENABLE_WS2812BPWM   "Enable the WS2812b-PWM device" ${DEFAULT_WS2812BPWM} )
 message(STATUS "ENABLE_WS2812BPWM = " ${ENABLE_WS2812BPWM})
 
-option(ENABLE_WS281XPWM   "Enable the WS281x-PWM device" OFF)
+option(ENABLE_WS281XPWM   "Enable the WS281x-PWM device" ${DEFAULT_WS281XPWM} )
 message(STATUS "ENABLE_WS281XPWM = " ${ENABLE_WS281XPWM})
 
-option(ENABLE_X11 "Enable the X11 grabber" OFF)
+option(ENABLE_X11 "Enable the X11 grabber" ${DEFAULT_X11})
 message(STATUS "ENABLE_X11 = " ${ENABLE_X11})
 
 option(ENABLE_QT5 "Enable QT5" OFF)
@@ -48,19 +73,19 @@ message(STATUS "ENABLE_TESTS = " ${ENABLE_TESTS})
 
 if(ENABLE_V4L2 AND NOT ENABLE_PROTOBUF)
 	message(FATAL_ERROR "V4L2 grabber requires PROTOBUF. Disable V4L2 or enable PROTOBUF")
-endif(ENABLE_V4L2 AND NOT ENABLE_PROTOBUF)
+endif()
 
 if(ENABLE_FB AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and framebuffer grabber cannot be used at the same time")
-endif(ENABLE_FB AND ENABLE_DISPMANX)
+endif()
 
 if(ENABLE_FB AND ENABLE_OSX)
 	message(FATAL_ERROR "osx grabber and framebuffer grabber cannot be used at the same time")
-endif(ENABLE_FB AND ENABLE_OSX)
+endif()
 
 if(ENABLE_OSX AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and osx grabber cannot be used at the same time")
-endif(ENABLE_OSX AND ENABLE_DISPMANX)
+endif()
 
 if (DEFINED INSTALL_PREFIX)
 	SET( ENABLE_SYSTEM_INSTALL ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,3 +158,9 @@ endif ()
 
 # Add the doxygen generation directory
 add_subdirectory(doc)
+
+# uninstall target
+configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+
+add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ if(ENABLE_OSX AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and osx grabber cannot be used at the same time")
 endif(ENABLE_OSX AND ENABLE_DISPMANX)
 
+option(ENABLE_SYSTEM_INSTALL "enables make install" OFF)
+message(STATUS "ENABLE_SYSTEM_INSTALL = " ${ENABLE_SYSTEM_INSTALL})
+
 
 SET ( PROTOBUF_INSTALL_BIN_DIR ${CMAKE_BINARY_DIR}/proto )
 SET ( PROTOBUF_INSTALL_LIB_DIR ${CMAKE_BINARY_DIR}/proto )

--- a/bin/create_all_releases.sh
+++ b/bin/create_all_releases.sh
@@ -1,43 +1,31 @@
 #!/bin/sh
-# create all directly for release with -DCMAKE_BUILD_TYPE=Release -Wno-dev
-# Create the x64 build
-mkdir build-x86x64
-cd build-x86x64
-cmake -DENABLE_DISPMANX=OFF -DENABLE_X11=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..
-make -j 4
-cd ..
 
-# Create the x32 build
-#mkdir build-x32
-#cd build-x32
-#cmake -DIMPORT_PROTOC=../build-x64/protoc_export.cmake -DENABLE_DISPMANX=OFF -DENABLE_X11=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..
-#make -j 4
-#cd ..
+# make_release <release name> <platform> [<cmake args ...>]
+make_release()
+{
+	echo
+	echo "--- build release for $1 ---"
+	echo
+	RELEASE=$1
+	PLATFORM=$2
+	shift 2
 
-# Create the RPI build
-mkdir build-rpi
-cd build-rpi
-cmake -DCMAKE_TOOLCHAIN_FILE="../Toolchain-rpi.cmake" -DIMPORT_PROTOC=../build-x86x64/protoc_export.cmake -DENABLE_WS2812BPWM=ON -DENABLE_WS281XPWM=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..
-make -j 4
-cd ..
+	mkdir -p build-${RELEASE}
+	cd  build-${RELEASE}
+	cmake -DPLATFORM=${PLATFORM} $@ -DCMAKE_BUILD_TYPE=Release -Wno-dev .. || exit 1
+	make -j $(nproc)  || exit 1
+	strip bin/*
+	cd ..
+	bin/create_release.sh . ${RELEASE}
+}
 
-# Create the WETEK build
-mkdir build-wetek
-cd build-wetek
-cmake -DCMAKE_TOOLCHAIN_FILE="../Toolchain-rpi.cmake" -DIMPORT_PROTOC=../build-x86x64/protoc_export.cmake -DENABLE_DISPMANX=OFF -DENABLE_FB=ON -DENABLE_AMLOGIC=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..
-make -j 4
-cd ..
+export PATH="$PATH:$HOME/raspberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin"
+CMAKE_PROTOC_FLAG="-DIMPORT_PROTOC=../build-x86x64/protoc_export.cmake"
 
-# Create the IMX6 build
-#mkdir build-imx6
-#cd build-imx6
-#cmake -DCMAKE_TOOLCHAIN_FILE="../Toolchain-imx6.cmake" -DIMPORT_PROTOC=../build-x32x64/protoc_export.cmake -DENABLE_DISPMANX=OFF -DENABLE_FB=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..
-#make -j 4
-#cd ..
+make_release x86x64 x86
+#make_release x32    x86 ${CMAKE_PROTOC_FLAG}
+make_release rpi    rpi  -DCMAKE_TOOLCHAIN_FILE="../Toolchain-rpi.cmake" ${CMAKE_PROTOC_FLAG}
+make_release wetek  rpi  -DCMAKE_TOOLCHAIN_FILE="../Toolchain-rpi.cmake" ${CMAKE_PROTOC_FLAG}
+#make_release imx6   imx6 -DCMAKE_TOOLCHAIN_FILE="../Toolchain-imx6.cmake" ${CMAKE_PROTOC_FLAG}
 
-bin/create_release.sh . x86x64
-#bin/create_release.sh . x32
-bin/create_release.sh . rpi
-bin/create_release.sh . wetek
-#bin/create_release.sh . imx6
 

--- a/bin/create_release.sh
+++ b/bin/create_release.sh
@@ -27,11 +27,7 @@ tar --create --gzip --absolute-names --show-transformed-names --ignore-failed-re
 	--transform "s:$repodir/bin/service/hyperion.systemd.sh:hyperion/init.d/hyperion.systemd.sh:" \
 	--transform "s:$repodir/bin/service/hyperion.initctl.sh:hyperion/init.d/hyperion.initctl.sh:" \
 	--transform "s://:/:g" \
-	"$builddir/bin/hyperiond" \
-	"$builddir/bin/hyperion-remote" \
-	"$builddir/bin/hyperion-v4l2" \
-	"$builddir/bin/hyperion-x11" \
-	"$builddir/bin/hyperion-dispmanx" \
+	"$builddir/bin/hyperion"* \
 	"$repodir/effects/"* \
 	"$repodir/bin/service/hyperion.init.sh" \
 	"$repodir/bin/service/hyperion.systemd.sh" \

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,22 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)
+

--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -31,9 +31,9 @@ set(Hyperion_AML_SOURCES
 
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_AML_HEADERS_MOC ${Hyperion_AML_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_AML_HEADERS_MOC ${Hyperion_AML_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 add_executable(${PROJECT_NAME}
 	${Hyperion_AML_HEADERS}
@@ -57,11 +57,11 @@ qt4_use_modules(${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()

--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -62,3 +62,6 @@ else(ENABLE_QT5)
 endif(ENABLE_QT5)
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()

--- a/src/hyperion-dispmanx/CMakeLists.txt
+++ b/src/hyperion-dispmanx/CMakeLists.txt
@@ -62,3 +62,6 @@ endif(ENABLE_QT5)
 
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()

--- a/src/hyperion-dispmanx/CMakeLists.txt
+++ b/src/hyperion-dispmanx/CMakeLists.txt
@@ -7,9 +7,9 @@ project(hyperion-dispmanx)
 # find QT
 if(ENABLE_QT5)
 	find_package(Qt5Widgets REQUIRED)
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork )
-endif(ENABLE_QT5)
+endif()
 
 # Find the BCM-package (VC control)
 find_package(BCM REQUIRED)
@@ -34,9 +34,9 @@ set(Hyperion_Dispmanx_SOURCES
 
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_Dispmanx_HEADERS_MOC ${Hyperion_Dispmanx_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_Dispmanx_HEADERS_MOC ${Hyperion_Dispmanx_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 add_executable( ${PROJECT_NAME}
 	${Hyperion_Dispmanx_HEADERS}
@@ -56,12 +56,12 @@ target_link_libraries( ${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
 
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()

--- a/src/hyperion-framebuffer/CMakeLists.txt
+++ b/src/hyperion-framebuffer/CMakeLists.txt
@@ -55,3 +55,8 @@ if(ENABLE_QT5)
 else(ENABLE_QT5)
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
 endif(ENABLE_QT5)
+
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()

--- a/src/hyperion-framebuffer/CMakeLists.txt
+++ b/src/hyperion-framebuffer/CMakeLists.txt
@@ -7,9 +7,9 @@ project(hyperion-framebuffer)
 # find QT
 if(ENABLE_QT5)
 	find_package(Qt5Widgets REQUIRED)
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork )
-endif(ENABLE_QT5)
+endif()
 
 include_directories(
 	${CMAKE_CURRENT_BINARY_DIR}/../../libsrc/protoserver
@@ -31,9 +31,9 @@ set(Hyperion_FB_SOURCES
 
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_FB_HEADERS_MOC ${Hyperion_FB_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_FB_HEADERS_MOC ${Hyperion_FB_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 add_executable( ${PROJECT_NAME}
 	${Hyperion_FB_HEADERS}
@@ -52,11 +52,11 @@ target_link_libraries( ${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()

--- a/src/hyperion-osx/CMakeLists.txt
+++ b/src/hyperion-osx/CMakeLists.txt
@@ -7,9 +7,9 @@ project(hyperion-osx)
 # find QT
 if(ENABLE_QT5)
 	find_package(Qt5Widgets REQUIRED)
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork )
-endif(ENABLE_QT5)
+endif()
 
 include_directories(
 	${CMAKE_CURRENT_BINARY_DIR}/../../libsrc/protoserver
@@ -31,9 +31,9 @@ set(Hyperion_OSX_SOURCES
 
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_OSX_HEADERS_MOC ${Hyperion_OSX_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_OSX_HEADERS_MOC ${Hyperion_OSX_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 add_executable( ${PROJECT_NAME}
 	${Hyperion_OSX_HEADERS}
@@ -52,6 +52,9 @@ target_link_libraries( ${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
+
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
+

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -7,9 +7,9 @@ if(ENABLE_QT5)
 	find_package(Qt5 COMPONENTS Core Gui Widgets Network REQUIRED)
 #	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}    ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 #	set(CMAKE_CXX_FLAGS "-fPIC")
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork)
-endif(ENABLE_QT5)
+endif()
 
 # The following I do not undrstand completely...
 # libQtCore.so uses some hardcoded library path inside which are incorrect after copying the file RPi file system
@@ -38,12 +38,12 @@ target_link_libraries(${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()
 

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -43,4 +43,7 @@ else(ENABLE_QT5)
 endif(ENABLE_QT5)
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()
 

--- a/src/hyperion-v4l2/CMakeLists.txt
+++ b/src/hyperion-v4l2/CMakeLists.txt
@@ -62,3 +62,6 @@ endif(ENABLE_QT5)
 
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()

--- a/src/hyperion-v4l2/CMakeLists.txt
+++ b/src/hyperion-v4l2/CMakeLists.txt
@@ -7,9 +7,9 @@ if(ENABLE_QT5)
 	find_package(Qt5Widgets REQUIRED)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}    ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 #	set(CMAKE_CXX_FLAGS "-fPIC")
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork)
-endif(ENABLE_QT5)
+endif()
 
 
 include_directories(
@@ -33,9 +33,9 @@ set(Hyperion_V4L2_SOURCES
 )
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_V4L2_MOC_SOURCES ${Hyperion_V4L2_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_V4L2_MOC_SOURCES ${Hyperion_V4L2_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 add_executable(${PROJECT_NAME}
 	${Hyperion_V4L2_HEADERS}
@@ -56,12 +56,11 @@ target_link_libraries(${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
-
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()

--- a/src/hyperion-x11/CMakeLists.txt
+++ b/src/hyperion-x11/CMakeLists.txt
@@ -62,3 +62,6 @@ else(ENABLE_QT5)
 endif(ENABLE_QT5)
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+endif()

--- a/src/hyperion-x11/CMakeLists.txt
+++ b/src/hyperion-x11/CMakeLists.txt
@@ -7,9 +7,9 @@ project(hyperion-x11)
 # find QT
 if(ENABLE_QT5)
 	find_package(Qt5Widgets REQUIRED)
-else(ENABLE_QT5)
+else()
 	find_package(Qt4 REQUIRED QtCore QtGui QtNetwork)
-endif(ENABLE_QT5)
+endif()
 
 # Find X11
 find_package(X11 REQUIRED)
@@ -34,9 +34,9 @@ set(Hyperion_X11_SOURCES
 
 if(ENABLE_QT5)
 	QT5_WRAP_CPP(Hyperion_X11_HEADERS_MOC ${Hyperion_X11_QT_HEADERS})
-else(ENABLE_QT5)
+else()
 	QT4_WRAP_CPP(Hyperion_X11_HEADERS_MOC ${Hyperion_X11_QT_HEADERS})
-endif(ENABLE_QT5)
+endif()
 
 
 add_executable(${PROJECT_NAME}
@@ -57,11 +57,11 @@ target_link_libraries(${PROJECT_NAME}
 
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
-else(ENABLE_QT5)
+else()
 	qt4_use_modules(${PROJECT_NAME} Core Gui Network )
-endif(ENABLE_QT5)
+endif()
 
-install ( TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS ${PROJECT_NAME} DESTINATION "${DEPLOY_DIR}/bin" )
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS ${PROJECT_NAME} DESTINATION "hyperion/bin" )
+	install ( TARGETS ${PROJECT_NAME} DESTINATION "bin" )
 endif()

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -12,31 +12,32 @@ target_link_libraries(hyperiond
 
 if (ENABLE_DISPMANX)
 	target_link_libraries(hyperiond dispmanx-grabber)
-endif (ENABLE_DISPMANX)
+endif ()
 
 if (ENABLE_FB)
 	target_link_libraries(hyperiond framebuffer-grabber)
-endif (ENABLE_FB)
+endif ()
 
 if (ENABLE_OSX)
 	target_link_libraries(hyperiond osx-grabber)
-endif (ENABLE_OSX)
+endif ()
 
 if (ENABLE_V4L2)
 	target_link_libraries(hyperiond v4l2-grabber)
-endif (ENABLE_V4L2)
+endif ()
 
 if (ENABLE_AMLOGIC)
 	target_link_libraries(hyperiond amlogic-grabber)
-endif (ENABLE_AMLOGIC)
+endif ()
 
 if (ENABLE_PROTOBUF)
 	target_link_libraries(hyperiond protoserver)
-endif (ENABLE_PROTOBUF)
+endif ()
 
-install ( TARGETS hyperiond DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+install ( TARGETS hyperiond DESTINATION "${DEPLOY_DIR}/bin" )
+install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "${DEPLOY_DIR}/share/hyperion/" )
 
 if (ENABLE_SYSTEM_INSTALL)
-	install ( TARGETS hyperiond DESTINATION "hyperion/bin" )
-	install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "hyperion/" )
+	install ( TARGETS hyperiond DESTINATION "bin" )
+	install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "share/hyperion/" )
 endif()

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -40,4 +40,5 @@ install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "${DEPLOY_DIR}/share
 if (ENABLE_SYSTEM_INSTALL)
 	install ( TARGETS hyperiond DESTINATION "bin" )
 	install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "share/hyperion/" )
+	install ( DIRECTORY ${CMAKE_SOURCE_DIR}/bin/service DESTINATION "share/hyperion/" )
 endif()

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -35,3 +35,8 @@ if (ENABLE_PROTOBUF)
 endif (ENABLE_PROTOBUF)
 
 install ( TARGETS hyperiond DESTINATION "${CMAKE_SOURCE_DIR}/deploy/bin" )
+
+if (ENABLE_SYSTEM_INSTALL)
+	install ( TARGETS hyperiond DESTINATION "hyperion/bin" )
+	install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "hyperion/" )
+endif()

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -36,6 +36,7 @@ endif ()
 
 install ( TARGETS hyperiond DESTINATION "${DEPLOY_DIR}/bin" )
 install ( DIRECTORY ${CMAKE_SOURCE_DIR}/effects DESTINATION "${DEPLOY_DIR}/share/hyperion/" )
+install ( DIRECTORY ${CMAKE_SOURCE_DIR}/bin/service DESTINATION "${DEPLOY_DIR}/share/hyperion/" )
 
 if (ENABLE_SYSTEM_INSTALL)
 	install ( TARGETS hyperiond DESTINATION "bin" )


### PR DESCRIPTION

general:

1. make life for people who compile hyperion a bit easier by providing "make install" "make uninstall" and a cmake PLATFORM option to reduce chance of messing up cmake options
2. code cleanup for cmakelists and bin/create_all_releases.sh

details:

1. now you can use make install and make uninstall. To get this working you have to provide an install prefix
`cmake -DINSTALL_PREFIX=/usr/local ..`
to install to /usr/local
or
`cmake -DINSTALL_PREFIX=/opt/hyperion ..`
to install to /opt/hyperion.
Currently this will install all binaries, effects and the service files. The service files aren't activated, you have to copy/link them manually if you wish. 
This part can be better - consider this as a start.

Normally you have to provide a list with cmake flags. 
e.g.:
`cmake -DENABLE_WS2812BPWM=ON -DENABLE_WS281XPWM=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..`
This can be made shorter with 
`cmake -DPLATFORM=rpi -DCMAKE_BUILD_TYPE=Release -Wno-dev .. `

ATM not all platform variations mentioned in compileHowTo.txt are integrated - I will add this in the next days. Currently supported: x86, rpi, wetek - OSX is autocratically detected.

2.  
in cmake 2.8 this:

`IF (expression)
ENDIF(expression)`
is not necessary. We can write

`IF (expression)
ENDIF()`

to make code more  readable.

In bin/create_all_releases.sh I eliminate code duplications and binaries are striped now (-> smaller size)

Reference a issue
#640


