### PR TITLE
Minimum luminance for backlight in dark scenes

### DIFF
--- a/include/utils/HslTransform.h
+++ b/include/utils/HslTransform.h
@@ -20,7 +20,7 @@ public:
 	/// @param saturationGain The used saturation gain
 	/// @param luminanceGain The used luminance gain
 	///
-	HslTransform(double saturationGain, double luminanceGain);
+	HslTransform(double saturationGain, double luminanceGain, double luminanceMinimum);
 
 	///
 	/// Destructor
@@ -54,6 +54,20 @@ public:
 	/// @return The current luminance gain
 	///
 	double getLuminanceGain() const;
+
+	///
+	/// Updates the luminance minimum
+	///
+	/// @param luminanceMinimum New luminance minimum
+	///
+	void setLuminanceMinimum(double luminanceMinimum);
+
+	///
+	/// Returns the luminance minimum
+	///
+	/// @return The current luminance minimum
+	///
+	double getLuminanceMinimum() const;
 
 	///
 	/// Apply the transform the the given RGB values.
@@ -97,4 +111,6 @@ private:
 	double _saturationGain;
 	/// The luminance gain
 	double _luminanceGain;
+	/// The luminance minimum
+	double _luminanceMinimum
 };

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -452,8 +452,9 @@ HslTransform * Hyperion::createHslTransform(const Json::Value & hslConfig)
 {
 	const double saturationGain = hslConfig.get("saturationGain", 1.0).asDouble();
 	const double luminanceGain  = hslConfig.get("luminanceGain",  1.0).asDouble();
+	const double luminanceMinimum = hslConfig.get("luminanceMinimum", 0.0).asDouble();
 
-	return new HslTransform(saturationGain, luminanceGain);
+	return new HslTransform(saturationGain, luminanceGain, luminanceMinimum);
 }
 
 RgbChannelTransform* Hyperion::createRgbChannelTransform(const Json::Value& colorConfig)

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -68,6 +68,11 @@
                             "type" : "number",
                             "required" : false,
                             "minimum" : 0.0
+                        },
+                        "luminanceMinimum" : {
+                            "type" : "number",
+                            "required" : false,
+                            "minimum" : 0.0
                         }
                     },
                     "additionalProperties" : false

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -455,6 +455,7 @@ void JsonClientConnection::handleServerInfoCommand(const Json::Value &)
 		transform["valueGain"]      = colorTransform->_hsvTransform.getValueGain();
 		transform["saturationLGain"] = colorTransform->_hslTransform.getSaturationGain();
 		transform["luminanceGain"]   = colorTransform->_hslTransform.getLuminanceGain();
+		transform["luminanceMinimum"]   = colorTransform->_hslTransform.getLuminanceMinimum();
 
 		Json::Value & threshold = transform["threshold"];
 		threshold.append(colorTransform->_rgbRedTransform.getThreshold());
@@ -603,6 +604,11 @@ void JsonClientConnection::handleTransformCommand(const Json::Value &message)
 	if (transform.isMember("luminanceGain"))
 	{
 		colorTransform->_hslTransform.setLuminanceGain(transform["luminanceGain"].asDouble());
+	}
+
+	if (transform.isMember("luminanceMinimum"))
+	{
+		colorTransform->_hslTransform.setLuminanceMinimum(transform["luminanceMinimum"].asDouble());
 	}
 
 	if (transform.isMember("threshold"))

--- a/libsrc/jsonserver/schema/schema-transform.json
+++ b/libsrc/jsonserver/schema/schema-transform.json
@@ -35,6 +35,11 @@
 					"required" : false,
 					"minimum" : 0.0
 				},
+				"luminanceMinimum" : {
+					"type" : "number",
+					"required" : false,
+					"minimum" : 0.0
+				},
 				"threshold": {
 					"type": "array",
 					"required": false,

--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -68,7 +68,7 @@ void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) con
 		if (l > 1.0f)
 			luminance = 1.0f;
 		else if (l < _luminanceMinimum)
-			luminance = _luminanceMinimum
+			luminance = _luminanceMinimum;
 		else
 			luminance = l;
 				

--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -65,11 +65,11 @@ void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) con
 			saturation = s;
 
 		float l = luminance * _luminanceGain;
+		if (l < _luminanceMinimum)
+			l = _luminanceMinimum;
 		if (l > 1.0f)
 			luminance = 1.0f;
-		else if (l < _luminanceMinimum)
-			luminance = _luminanceMinimum;
-		else
+		else 
 			luminance = l;
 				
 		hsl2rgb(hue, saturation, luminance, red, green, blue);

--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -4,13 +4,15 @@
 
 HslTransform::HslTransform() :
 	_saturationGain(1.0),
-	_luminanceGain(1.0)
+	_luminanceGain(1.0),
+	_luminanceMinimum(0.0)
 {
 }
 
-HslTransform::HslTransform(double saturationGain, double luminanceGain) :
+HslTransform::HslTransform(double saturationGain, double luminanceGain, double luminanceMinimum) :
 	_saturationGain(saturationGain),
-	_luminanceGain(luminanceGain)
+	_luminanceGain(luminanceGain),
+	_luminanceMinimum(luminanceMinimum)
 {
 }
 
@@ -38,6 +40,16 @@ double HslTransform::getLuminanceGain() const
 	return _luminanceGain;
 }
 
+void HslTransform::setLuminanceMinimum(double luminanceMinimum)
+{
+	_luminanceMinimum = luminanceMinimum;
+}
+
+double HslTransform::getLuminanceMinimum() const
+{
+	return _luminanceMinimum;
+}
+
 void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) const
 {
 	if (_saturationGain != 1.0 || _luminanceGain != 1.0)
@@ -55,6 +67,8 @@ void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) con
 		float l = luminance * _luminanceGain;
 		if (l > 1.0f)
 			luminance = 1.0f;
+		else if (l < _luminanceMinimum)
+			luminance = _luminanceMinimum
 		else
 			luminance = l;
 				

--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -52,7 +52,7 @@ double HslTransform::getLuminanceMinimum() const
 
 void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) const
 {
-	if (_saturationGain != 1.0 || _luminanceGain != 1.0)
+	if (_saturationGain != 1.0 || _luminanceGain != 1.0 || _luminanceMinimum != 0.0)
 	{
 		uint16_t hue;
 		float saturation, luminance;

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -192,7 +192,7 @@ void JsonConnection::clearAll()
 	parseReply(reply);
 }
 
-void JsonConnection::setTransform(std::string * transformId, double * saturation, double * value, double * saturationL, double * luminance, ColorTransformValues *threshold, ColorTransformValues *gamma, ColorTransformValues *blacklevel, ColorTransformValues *whitelevel)
+void JsonConnection::setTransform(std::string * transformId, double * saturation, double * value, double * saturationL, double * luminance, double * luminanceMin, ColorTransformValues *threshold, ColorTransformValues *gamma, ColorTransformValues *blacklevel, ColorTransformValues *whitelevel)
 {
 	std::cout << "Set color transforms" << std::endl;
 
@@ -225,6 +225,12 @@ void JsonConnection::setTransform(std::string * transformId, double * saturation
 	{
 		transform["luminanceGain"] = *luminance;
 	}
+	
+	if (luminanceMin != nullptr)
+	{
+		transform["luminanceMinimum"] = *luminanceMin;
+	}
+	
 	if (threshold != nullptr)
 	{
 		Json::Value & v = transform["threshold"];

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -93,6 +93,7 @@ public:
 	/// @param value The HSV value gain
 	/// @param saturationL The HSL saturation gain
 	/// @param luminance The HSL luminance gain
+	/// @param luminanceMin The HSL luminance minimum
 	/// @param threshold The threshold
 	/// @param gamma The gamma value
 	/// @param blacklevel The blacklevel
@@ -104,6 +105,7 @@ public:
 			double * value,
 			double * saturationL,
 			double * luminance,
+			double * luminanceMin,
 			ColorTransformValues * threshold,
 			ColorTransformValues * gamma,
 			ColorTransformValues * blacklevel,

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -71,6 +71,7 @@ int main(int argc, char * argv[])
 		DoubleParameter    & argValue      = parameters.add<DoubleParameter>   ('v', "value"     , "!DEPRECATED! Will be removed soon! Set the HSV value gain of the leds");
 		DoubleParameter    & argSaturationL = parameters.add<DoubleParameter>  ('u', "saturationL", "Set the HSL saturation gain of the leds");
 		DoubleParameter    & argLuminance  = parameters.add<DoubleParameter>   ('m', "luminance" , "Set the HSL luminance gain of the leds");
+		DoubleParameter    & argLuminanceMin  = parameters.add<DoubleParameter>   ('n', "luminanceMin" , "Set the HSL luminance minimum of the leds (backlight)");
 		TransformParameter & argGamma      = parameters.add<TransformParameter>('g', "gamma"     , "Set the gamma of the leds (requires 3 space seperated values)");
 		TransformParameter & argThreshold  = parameters.add<TransformParameter>('t', "threshold" , "Set the threshold of the leds (requires 3 space seperated values between 0.0 and 1.0)");
 		TransformParameter & argBlacklevel = parameters.add<TransformParameter>('b', "blacklevel", "!DEPRECATED! Will be removed soon! Set the blacklevel of the leds (requires 3 space seperated values which are normally between 0.0 and 1.0)");
@@ -103,7 +104,7 @@ int main(int argc, char * argv[])
 		}
 
 		// check if at least one of the available color transforms is set
-		bool colorTransform = argSaturation.isSet() || argValue.isSet() || argSaturationL.isSet() || argLuminance.isSet() || argThreshold.isSet() || argGamma.isSet() || argBlacklevel.isSet() || argWhitelevel.isSet();
+		bool colorTransform = argSaturation.isSet() || argValue.isSet() || argSaturationL.isSet() || argLuminance.isSet() || argLuminanceMin.isSet() || argThreshold.isSet() || argGamma.isSet() || argBlacklevel.isSet() || argWhitelevel.isSet();
 		bool colorAdjust = argRAdjust.isSet() || argGAdjust.isSet() || argBAdjust.isSet();
 		bool colorModding = colorTransform || colorAdjust || argCorrection.isSet() || argTemperature.isSet();
 		
@@ -124,6 +125,7 @@ int main(int argc, char * argv[])
 			std::cerr << "  " << argValue.usageLine() << std::endl;
 			std::cerr << "  " << argSaturationL.usageLine() << std::endl;
 			std::cerr << "  " << argLuminance.usageLine() << std::endl;
+			std::cerr << "  " << argLuminanceMin.usageLine() << std::endl;
 			std::cerr << "  " << argThreshold.usageLine() << std::endl;
 			std::cerr << "  " << argGamma.usageLine() << std::endl;
 			std::cerr << "  " << argBlacklevel.usageLine() << std::endl;
@@ -216,7 +218,7 @@ int main(int argc, char * argv[])
 			if (colorTransform)
 			{
 				std::string transId;
-				double saturation, value, saturationL, luminance;
+				double saturation, value, saturationL, luminance, luminanceMin;
 				ColorTransformValues threshold, gamma, blacklevel, whitelevel;
 
 				if (argId.isSet())         transId    = argId.getValue();
@@ -224,6 +226,7 @@ int main(int argc, char * argv[])
 				if (argValue.isSet())      value      = argValue.getValue();
 				if (argSaturationL.isSet()) saturationL = argSaturationL.getValue();
 				if (argLuminance.isSet())  luminance      = argLuminance.getValue();
+				if (argLuminanceMin.isSet())  luminanceMin = argLuminanceMin.getValue();
 				if (argThreshold.isSet())  threshold  = argThreshold.getValue();
 				if (argGamma.isSet())      gamma      = argGamma.getValue();
 				if (argBlacklevel.isSet()) blacklevel = argBlacklevel.getValue();
@@ -235,6 +238,7 @@ int main(int argc, char * argv[])
 						argValue.isSet()      ? &value      : nullptr,
 						argSaturationL.isSet() ? &saturationL : nullptr,
 						argLuminance.isSet()  ? &luminance  : nullptr,
+						argLuminanceMin.isSet() ? &luminanceMin  : nullptr,
 						argThreshold.isSet()  ? &threshold  : nullptr,
 						argGamma.isSet()      ? &gamma      : nullptr,
 						argBlacklevel.isSet() ? &blacklevel : nullptr,


### PR DESCRIPTION
As suggested in the [forum](https://hyperion-project.org/threads/better-color-adjustment.104/#post-641) I added a minimum luminance variable to the HSL transform. This variable can be used to brighten all dark colors including black to provide a led "backlight" in dark scenes. I hope I found all necessary places in the hyperion code and json schemas. I also added the variable to the hyperion-remote as 'n' parameter.

