### PR TITLE
XRender support for X11 Grabber

### DIFF
--- a/include/grabber/X11Grabber.h
+++ b/include/grabber/X11Grabber.h
@@ -6,7 +6,6 @@
 
 // X11 includes
 #include <X11/Xlib.h>
-
 #include <X11/extensions/Xrender.h>
 #include <X11/extensions/XShm.h>
 #include <sys/ipc.h>
@@ -16,7 +15,7 @@ class X11Grabber
 {
 public:
 
-    X11Grabber(int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation);
+    X11Grabber(bool useXGetImage, int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation);
 
 	virtual ~X11Grabber();
 
@@ -28,7 +27,8 @@ public:
 
 private:
     ImageResampler _imageResampler;
-
+    
+    bool _useXGetImage, _XShmAvailable, _XShmPixmapAvailable, _XRenderAvailable;
     int _cropLeft;
     int _cropRight;
     int _cropTop;
@@ -41,6 +41,13 @@ private:
 	Display* _x11Display;
 	Window _window;
 	XWindowAttributes _windowAttr;
+	
+	Pixmap _pixmap;
+	XRenderPictFormat* _srcFormat;
+	XRenderPictFormat* _dstFormat;
+	XRenderPictureAttributes _pictAttr;
+	Picture _srcPicture;
+	Picture _dstPicture;
 
 	unsigned _screenWidth;
 	unsigned _screenHeight;

--- a/src/hyperion-x11/CMakeLists.txt
+++ b/src/hyperion-x11/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(${PROJECT_NAME}
 	protoserver
 	x11-grabber
 	${X11_LIBRARIES}
+	${X11_Xrender_LIB}
 	pthread
 )
 

--- a/src/hyperion-x11/X11Wrapper.cpp
+++ b/src/hyperion-x11/X11Wrapper.cpp
@@ -2,9 +2,9 @@
 // Hyperion-X11 includes
 #include "X11Wrapper.h"
 
-X11Wrapper::X11Wrapper(int grabInterval, int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation) :
+X11Wrapper::X11Wrapper(int grabInterval, bool useXGetImage, int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation) :
     _timer(this),
-    _grabber(cropLeft, cropRight, cropTop, cropBottom, horizontalPixelDecimation, verticalPixelDecimation)
+    _grabber(useXGetImage, cropLeft, cropRight, cropTop, cropBottom, horizontalPixelDecimation, verticalPixelDecimation)
 {
     _timer.setSingleShot(false);
     _timer.setInterval(grabInterval);

--- a/src/hyperion-x11/X11Wrapper.h
+++ b/src/hyperion-x11/X11Wrapper.h
@@ -9,7 +9,7 @@ class X11Wrapper : public QObject
 {
     Q_OBJECT
 public:
-    X11Wrapper(int grabInterval, int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation);
+    X11Wrapper(int grabInterval, bool useXGetImage, int cropLeft, int cropRight, int cropTop, int cropBottom, int horizontalPixelDecimation, int verticalPixelDecimation);
 
     const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-x11/hyperion-x11.cpp
+++ b/src/hyperion-x11/hyperion-x11.cpp
@@ -36,6 +36,7 @@ int main(int argc, char ** argv)
         ParameterSet & parameters = optionParser.getParameters();
 
         IntParameter           & argFps             = parameters.add<IntParameter>          ('f', "framerate",        "Capture frame rate [default: 10]");
+        SwitchParameter<>      & argXGetImage       = parameters.add<SwitchParameter<>>     ('x', "xgetimage",        "Use XGetImage instead of XRender");
         IntParameter           & argCropWidth       = parameters.add<IntParameter>          (0x0, "crop-width",       "Number of pixels to crop from the left and right sides of the picture before decimation [default: 0]");
         IntParameter           & argCropHeight      = parameters.add<IntParameter>          (0x0, "crop-height",      "Number of pixels to crop from the top and the bottom of the picture before decimation [default: 0]");
         IntParameter           & argCropLeft        = parameters.add<IntParameter>          (0x0, "crop-left",        "Number of pixels to crop from the left of the picture before decimation (overrides --crop-width)");
@@ -75,8 +76,10 @@ int main(int argc, char ** argv)
 
         // Create the X11 grabbing stuff
         int grabInterval = 1000 / argFps.getValue();
+        bool useXGetImage = argXGetImage.isSet();
         X11Wrapper x11Wrapper(
                     grabInterval,
+                    useXGetImage,
                     argCropLeft.getValue(),
                     argCropRight.getValue(),
                     argCropTop.getValue(),


### PR DESCRIPTION
**Sorry but only in German Language.**

**1.** Tell us something about your changes.

1. Der X11 Grabber unterstützt nun auch die [XRender Erweiterung](https://en.wikipedia.org/wiki/X_Rendering_Extension) soweit diese vorhanden ist. Sollte diese nicht vorhanden sein, siehe Punkt 3.

2. Die Unterstützung der [MIT-SHM Erweiterung](https://en.wikipedia.org/wiki/MIT-SHM) ist weiterhin vorhanden. Sollte diese nicht vorhanden sein, siehe Punkt 3.

3. Die Ausweichmöglichkeit (XGetImage) für ältere Systeme wurde wieder hinzugefügt.
Diese lässt sich auch explizit mit den Parameter "-x" oder "--xgetimage" erzwingen.

**2.** If this changes affect the .conf file. Please provide the changed section

Nein

**3.** Reference a issue (optional)

1. #282 
2. [#458](https://github.com/hyperion-project/hyperion/pull/458#issuecomment-206591973)
3. #451
4. #568