### PR TITLE
better output for effect path loading

### DIFF
--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -30,7 +30,6 @@ EffectEngine::EffectEngine(Hyperion * hyperion, const Json::Value & jsonEffectCo
 	connect(_hyperion, SIGNAL(allChannelsCleared()), this, SLOT(allChannelsCleared()));
 
 	// read all effects
-	bool effectPathExists = false;
 	const Json::Value & paths = jsonEffectConfig["paths"];
 	for (Json::UInt i = 0; i < paths.size(); ++i)
 	{
@@ -38,7 +37,6 @@ EffectEngine::EffectEngine(Hyperion * hyperion, const Json::Value & jsonEffectCo
 		QDir directory(QString::fromStdString(path));
 		if (directory.exists())
 		{
-			effectPathExists = true;
 			int efxCount = 0;
 			QStringList filenames = directory.entryList(QStringList() << "*.json", QDir::Files, QDir::Name | QDir::IgnoreCase);
 			foreach (const QString & filename, filenames)
@@ -54,9 +52,9 @@ EffectEngine::EffectEngine(Hyperion * hyperion, const Json::Value & jsonEffectCo
 		}
 	}
 
-	if (!effectPathExists)
+	if (_availableEffects.size() == 0)
 	{
-		std::cerr << "EFFECTENGINE ERROR: no usuable effect directories found" << std::endl;
+		std::cerr << "EFFECTENGINE ERROR: no effects found, check your effect directories" << std::endl;
 	}
 
 	// initialize the python interpreter


### PR DESCRIPTION
**1.** Tell us something about your changes.
tune output for effect folder loading. Prints successfully loaded folders.
When no effect found an error is printed

example output

`EFFECTENGINE INFO: 26 effects loaded from directory /opt/hyperion/effects`

or the error case (2 dirs in config, both exists, but contain no effect)
```
EFFECTENGINE INFO: 0 effects loaded from directory e1
EFFECTENGINE INFO: 0 effects loaded from directory e2
EFFECTENGINE ERROR: no effects found, check if your effect directories are valid and contain effects
```

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)
https://hyperion-project.org/threads/effectengine-add-all-paths-to-json.101/



