### PR TITLE
prevent colorsmoothing from flooding led device

### DIFF
--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -480,7 +480,7 @@ RgbChannelCorrection* Hyperion::createRgbChannelCorrection(const Json::Value& co
 
 RgbChannelAdjustment* Hyperion::createRgbChannelAdjustment(const Json::Value& colorConfig, const RgbChannel color)
 {
-	int varR, varG, varB;
+	int varR=0, varG=0, varB=0;
 	if (color == RED) 
 	{
 		varR = colorConfig.get("redChannel", 255).asInt();
@@ -618,10 +618,10 @@ MessageForwarder * Hyperion::getForwarder()
 Hyperion::Hyperion(const Json::Value &jsonConfig) :
 	_ledString(createLedString(jsonConfig["leds"], createColorOrder(jsonConfig["device"]))),
 	_muxer(_ledString.leds().size()),
-	_raw2ledAdjustment(createLedColorsAdjustment(_ledString.leds().size(), jsonConfig["color"])),
+	_raw2ledTransform(createLedColorsTransform(_ledString.leds().size(), jsonConfig["color"])),
 	_raw2ledCorrection(createLedColorsCorrection(_ledString.leds().size(), jsonConfig["color"])),
 	_raw2ledTemperature(createLedColorsTemperature(_ledString.leds().size(), jsonConfig["color"])),
-	_raw2ledTransform(createLedColorsTransform(_ledString.leds().size(), jsonConfig["color"])),
+	_raw2ledAdjustment(createLedColorsAdjustment(_ledString.leds().size(), jsonConfig["color"])),
 	_device(LedDeviceFactory::construct(jsonConfig["device"])),
 	_effectEngine(nullptr),
 	_messageForwarder(createMessageForwarder(jsonConfig["forwarder"])),

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -14,7 +14,8 @@ LinearColorSmoothing::LinearColorSmoothing(
 	_updateInterval(1000 / ledUpdateFrequency_hz),
 	_settlingTime(settlingTime_ms),
 	_timer(),
-	_outputDelay(updateDelay)
+	_outputDelay(updateDelay),
+	_writeToLedsEnable(true)
 {
 	_timer.setSingleShot(false);
 	_timer.setInterval(_updateInterval);
@@ -82,9 +83,11 @@ void LinearColorSmoothing::updateLeds()
 		_previousTime = now;
 
 		queueColors(_previousValues);
+		_writeToLedsEnable = false;
 	}
 	else
 	{
+		_writeToLedsEnable = true;
 		float k = 1.0f - 1.0f * deltaTime / (_targetTime - _previousTime);
 
 		for (size_t i = 0; i < _previousValues.size(); ++i)
@@ -107,7 +110,8 @@ void LinearColorSmoothing::queueColors(const std::vector<ColorRgb> & ledColors)
 	if (_outputDelay == 0)
 	{
 		// No output delay => immediate write
-		_ledDevice->write(ledColors);
+		if ( _writeToLedsEnable )
+			_ledDevice->write(ledColors);
 	}
 	else
 	{
@@ -116,7 +120,8 @@ void LinearColorSmoothing::queueColors(const std::vector<ColorRgb> & ledColors)
 		// If the delay-buffer is filled pop the front and write to device
 		if (_outputQueue.size() > _outputDelay)
 		{
-			_ledDevice->write(_outputQueue.front());
+			if ( _writeToLedsEnable )
+				_ledDevice->write(_outputQueue.front());
 			_outputQueue.pop_front();
 		}
 	}

--- a/libsrc/hyperion/LinearColorSmoothing.h
+++ b/libsrc/hyperion/LinearColorSmoothing.h
@@ -80,4 +80,6 @@ private:
 	/** The output queue */
 	std::list<std::vector<ColorRgb> > _outputQueue;
 
+	// prevent sending data to device when no intput data is sent
+	bool _writeToLedsEnable;
 };

--- a/libsrc/utils/RgbChannelCorrection.cpp
+++ b/libsrc/utils/RgbChannelCorrection.cpp
@@ -6,8 +6,8 @@
 
 RgbChannelCorrection::RgbChannelCorrection() :
 	_correctionR(255),
-	_correctionB(255),
-	_correctionG(255)
+	_correctionG(255),
+	_correctionB(255)
 {
 	initializeMapping();
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.
in current implementation activated color smoothing sends periodically to led device. It also sends data when no new data is available and smoothing buffer is empty. 
This is wasted cpu power and can lead to unwanted effects. see issue #318 

This PR changes this behaviour. The smoothing sends only when data available, as it does when smoothing is switched off.

additional: I remove some compiler warnings from color correction code

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)
#318 
