### PR TITLE
[aml] do not unconditionaly use qt4 modules

### DIFF
--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -50,11 +50,6 @@ target_link_libraries(${PROJECT_NAME}
 	pthread
 )
 
-qt4_use_modules(${PROJECT_NAME}
-	Core
-	Gui
-	Network)
-
 if(ENABLE_QT5)
 	qt5_use_modules(${PROJECT_NAME} Widgets Core Gui Network)
 else()


### PR DESCRIPTION
IMPORTANT: Please don´t commit to master, we will test your changes first at the beta branch!
**1.** Tell us something about your changes.

when building with -DENABLE_QT5=ON and no qt4 is installed, build will fail. qt4 modules are conditionaly used few lines below so this is just clean up.

**2.** If this changes affect the .conf file. Please provide the changed section
**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


