### PR TITLE
Colorless Backlight

### DIFF
--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -67,7 +67,7 @@ void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) con
 		float l = luminance * _luminanceGain;
 		if (l < _luminanceMinimum)
 		{
-			saturation *= l/_luminanceMinimum;
+			saturation *= 0;
 			l = _luminanceMinimum;
 		}
 		if (l > 1.0f)

--- a/libsrc/utils/HslTransform.cpp
+++ b/libsrc/utils/HslTransform.cpp
@@ -67,7 +67,7 @@ void HslTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue) con
 		float l = luminance * _luminanceGain;
 		if (l < _luminanceMinimum)
 		{
-			saturation *= 0;
+			saturation = 0;
 			l = _luminanceMinimum;
 		}
 		if (l > 1.0f)


### PR DESCRIPTION
Set the saturation to 0 when apllying backlight. [See forum](https://hyperion-project.org/threads/better-color-adjustment.104/page-2#post-1668).