### PR TITLE
Set default output device for WS2812SPI

### DIFF
--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -146,7 +146,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	}
 	else if (type == "ws2812spi")
 	{
-		const std::string output = deviceConfig["output"].asString();
+		const std::string output = deviceConfig.get("output", "/dev/spidev0.0").asString();
 		const unsigned rate      = deviceConfig.get("rate",2857143).asInt();
 
 		LedDeviceWs2812SPI* deviceWs2812SPI = new LedDeviceWs2812SPI(output, rate);


### PR DESCRIPTION
**1.** 	Set default output device for WS2812SPI. With this change the WS2812SPI device works with Hypercon out of the box.
**2.** If this changes affect the .conf file. Please provide the changed section
**3.** Reference a issue (optional)

With this change the WS2812SPI device works with Hypercon out of the box. Otherwise a manual json edit is required to get the device working.