### PR TITLE
fixed name of libqt4 for ubuntu repositories

### DIFF
--- a/CompileHowto.txt
+++ b/CompileHowto.txt
@@ -1,6 +1,6 @@
 # Install the required tools and dependencies
 sudo apt-get update
-sudo apt-get install git cmake build-essential libQt4-dev libusb-1.0-0-dev python-dev libxrender-dev python
+sudo apt-get install git cmake build-essential libqt4-dev libusb-1.0-0-dev python-dev libxrender-dev python
 
 # Arch/ALARM dependencies
 sudo pacman -S --needed git cmake base-devel qt4 libusb libxrender icu


### PR DESCRIPTION
the name of the package is libqt4-dev not libQt4-dev

IMPORTANT: This repository no longer accepts new features or additions. Just bugfixes! Please commit to the repository "hyperion.ng" for new features.
**1.** Tell us something about your changes.
**2.** If this changes affect the .conf file. Please provide the changed section
**3.** Reference a issue (optional)


