### PR TITLE
fixed missing libs in openELEC 8.x

### DIFF
--- a/bin/create_oe_depedencies.sh
+++ b/bin/create_oe_depedencies.sh
@@ -22,6 +22,8 @@ tar --create --verbose --gzip --absolute-names --show-transformed-names --derefe
 	"$IMX6_ROOTFS/usr/lib/arm-linux-gnueabihf/libXext.so.6" \
 	"$IMX6_ROOTFS/usr/lib/arm-linux-gnueabihf/libXrender.so.1" \
 	"$IMX6_ROOTFS/usr/lib/arm-linux-gnueabihf/libXt.so.6" \
+	"$IMX6_ROOTFS/usr/lib/arm-linux-gnueabihf/libfontconfig.so.1" \
+	"$IMX6_ROOTFS/usr/lib/arm-linux-gnueabihf/libfreetype.so.6" \
 	"./openelec/hyperiond.sh" \
 	"./openelec/hyperion-v4l2.sh" \
 	"./openelec/hyperion-remote.sh"


### PR DESCRIPTION
Added missing libs for openELEC 8.x
-libfreetype.so.6
-libfontconfig.so.1

Users are getting the following error message after updating openELEC to 8.x
_/storage/hyperion/bin/hyperion-remote: error while loading shared libraries: libfontconfig.so.1: cannot open shared object file: No such file or directory_

There are missing two libraries (see above) in openELEC 8.x.
Added them to create_oe_depedencies.sh to add these libs to the hyperion.deps.openelec-x86x64.tar.gz

These issue was also reported in the hyperion forum (https://hyperion-project.org/threads/broke-hyperion-on-new-kodi-update.593)


