### PR TITLE
Updated rpi_ws281x submodule to latest commits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "dependencies/external/rpi_ws281x"]
 	path = dependencies/external/rpi_ws281x
 	url = https://github.com/hyperion-project/rpi_ws281x.git
-	branch = sk6812
+	branch = master

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,6 +8,7 @@ if(ENABLE_WS281XPWM)
 	add_library(ws281x
 		external/rpi_ws281x/mailbox.c external/rpi_ws281x/ws2811.c
 		external/rpi_ws281x/pwm.c external/rpi_ws281x/dma.c
+		external/rpi_ws281x/pcm.c
 		external/rpi_ws281x/rpihw.c)
 endif()
 


### PR DESCRIPTION
This includes support for newer RPI hardware versions.

It's been a while since i've had the pleasure of doing pull requests with updated submodules.
Can someone please check that this works for them too?

IMPORTANT: This repository no longer accepts new features or additions. Just bugfixes! Please commit to the repository "hyperion.ng" for new features.
**1.** Tell us something about your changes.
Updated hyperion-project master branch to latest version
small modifications to CMake file to support the new version

**2.** If this changes affect the .conf file. Please provide the changed section
nope

**3.** Reference a issue (optional)
All those people who needed to hack the rpihw.c file and build from source so this would work with newer RPI hardware versions (like CM, ZeroW...)


