### PR TITLE
Fix no decleration of `assert` with GCC 7.2

### DIFF
--- a/include/utils/Image.h
+++ b/include/utils/Image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // STL includes
+#include <cassert>
 #include <vector>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
Add a missing include for cassert to fix the -fpermissive compiler
error.


This fixes building hyperion on Arch Linux or any other distro with GCC 7.2

Fixes issue #766