### PR TITLE
Fix XBMCVideoChecker for Kodi 18

### DIFF
--- a/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
+++ b/libsrc/xbmcvideochecker/XBMCVideoChecker.cpp
@@ -62,7 +62,8 @@ void XBMCVideoChecker::receiveReply()
 // silence - no "debug" code should be at the log
 //	std::cout << "KODICHECK INFO: Kodi Message: " << reply.toStdString() << std::endl;
 
-	if (reply.contains("\"method\":\"Player.OnPlay\""))
+	if ( (_xbmcVersion < 18 && reply.contains("\"method\":\"Player.OnPlay\"")) ||
+	     (_xbmcVersion >= 18 && reply.contains("\"method\":\"Player.OnAVStart\"")) )
 	{
 		// send a request for the current player state
 		_socket.write(_activePlayerRequest.toUtf8());


### PR DESCRIPTION
This should fix #770 

Trigger on OnAVStart instead of OnPlay for Kodi 18. OnPlay is sent too early, using OnAVStart makes sure the stream has actually been started and the current player etc can be safely queried.