### PR TITLE
initialized led_string to prevent segfaults

### DIFF
--- a/libsrc/leddevice/LedDeviceWS281x.cpp
+++ b/libsrc/leddevice/LedDeviceWS281x.cpp
@@ -9,6 +9,7 @@ LedDeviceWS281x::LedDeviceWS281x(const int gpio, const int leds, const uint32_t 
 std::cout << "whiteAlgorithm :" << whiteAlgorithm << ":\n";
 
 	initialized = false;
+	led_string = {};
 	led_string.freq = freq;
 	led_string.dmanum = dmanum;
 	if (pwmchannel != 0 && pwmchannel != 1) {


### PR DESCRIPTION
**1.** Tell us something about your changes.
I got segfaults when using an SK6812 stripe with hyperiond on a raspberry 2B V1.1. The strandtest.py from the ws281x submodule worked flawlessly.  I've added a init for the led_string which fixes the issue for me. 

**3.** Reference a issue (optional)
I think this applies to #793

Thanks for your work. Hyperion is awesome.

