### PR TITLE
Fix - Philips Hue RGB Brightness Color Conversion

### DIFF
--- a/libsrc/leddevice/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/LedDevicePhilipsHue.cpp
@@ -111,8 +111,8 @@ CiColor PhilipsHueLight::rgbToCiColor(float red, float green, float blue) {
 	if (std::isnan(cy)) {
 		cy = 0.0f;
 	}
-	// RGB to HSV Convertion for Brightness Value, not XYZ Space.
-	float bri = fmax(fmax(red, green), blue);
+	// RGB to HSV/B Conversion after gamma correction use V for brightness, not Y from XYZ Space.
+	float bri = fmax(fmax(r, g), b);
 	CiColor xy = { cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.
 	if (!isPointInLampsReach(xy)) {


### PR DESCRIPTION
Hue RGB Color Conversion for Brightness is wrong! - use RGB to HSV instead of XYZ Space!
For correct use, reset brightnessFactor (if set) back to 1.0 in config! - It was just a Workaround, not the Solution!