### PR TITLE
Added effect name to JSON 'serverinfo' output in activeEffects

### DIFF
--- a/include/effectengine/ActiveEffectDefinition.h
+++ b/include/effectengine/ActiveEffectDefinition.h
@@ -8,6 +8,7 @@
 
 struct ActiveEffectDefinition
 {
+    std::string name;
 	std::string script;
 	int priority;
 	int timeout;

--- a/include/effectengine/EffectEngine.h
+++ b/include/effectengine/EffectEngine.h
@@ -49,7 +49,7 @@ private slots:
 
 private:
 	/// Run the specified effect on the given priority channel and optionally specify a timeout
-	int runEffectScript(const std::string &script, const Json::Value & args, int priority, int timeout = -1);
+	int runEffectScript(const std::string & name, const std::string &script, const Json::Value & args, int priority, int timeout = -1);
 
 private:
 	Hyperion * _hyperion;

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -49,9 +49,10 @@ void Effect::registerHyperionExtensionModule()
 	PyImport_AppendInittab("hyperion", &PyInit_hyperion);
 }
 
-Effect::Effect(PyThreadState * mainThreadState, int priority, int timeout, const std::string & script, const Json::Value & args) :
+Effect::Effect(PyThreadState * mainThreadState, const std::string & name, int priority, int timeout, const std::string & script, const Json::Value & args) :
 	QThread(),
 	_mainThreadState(mainThreadState),
+	_name(name),
 	_priority(priority),
 	_timeout(timeout),
 	_script(script),

--- a/libsrc/effectengine/Effect.h
+++ b/libsrc/effectengine/Effect.h
@@ -14,10 +14,12 @@ class Effect : public QThread
 	Q_OBJECT
 
 public:
-    Effect(PyThreadState * mainThreadState, int priority, int timeout, const std::string & script, const Json::Value & args = Json::Value());
+    Effect(PyThreadState * mainThreadState, const std::string & name, int priority, int timeout, const std::string & script, const Json::Value & args = Json::Value());
 	virtual ~Effect();
 
 	virtual void run();
+    
+    std::string getName() const { return _name; }
 
 	int getPriority() const;
 	
@@ -62,6 +64,8 @@ private:
 
 private:
     PyThreadState * _mainThreadState;
+
+    const std::string _name;
 
 	const int _priority;
 

--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -86,6 +86,7 @@ const std::list<ActiveEffectDefinition> &EffectEngine::getActiveEffects()
 	for (Effect * effect : _activeEffects)
 	{
 		ActiveEffectDefinition activeEffectDefinition;
+		activeEffectDefinition.name = effect->getName();
 		activeEffectDefinition.script = effect->getScript();
 		activeEffectDefinition.priority = effect->getPriority();
 		activeEffectDefinition.timeout = effect->getTimeout();
@@ -174,16 +175,16 @@ int EffectEngine::runEffect(const std::string &effectName, const Json::Value &ar
 		return -1;
 	}
 
-	return runEffectScript(effectDefinition->script, args.isNull() ? effectDefinition->args : args, priority, timeout);
+	return runEffectScript(effectName, effectDefinition->script, args.isNull() ? effectDefinition->args : args, priority, timeout);
 }
 
-int EffectEngine::runEffectScript(const std::string &script, const Json::Value &args, int priority, int timeout)
+int EffectEngine::runEffectScript(const std::string & name, const std::string &script, const Json::Value &args, int priority, int timeout)
 {
 	// clear current effect on the channel
 	channelCleared(priority);
 
 	// create the effect
-    Effect * effect = new Effect(_mainThreadState, priority, timeout, script, args);
+    Effect * effect = new Effect(_mainThreadState, name, priority, timeout, script, args);
 	connect(effect, SIGNAL(setColors(int,std::vector<ColorRgb>,int,bool)), _hyperion, SLOT(setColors(int,std::vector<ColorRgb>,int,bool)), Qt::QueuedConnection);
 	connect(effect, SIGNAL(effectFinished(Effect*)), this, SLOT(effectFinished(Effect*)));
 	_activeEffects.push_back(effect);

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -524,6 +524,7 @@ void JsonClientConnection::handleServerInfoCommand(const Json::Value &)
 	for (const ActiveEffectDefinition & activeEffectDefinition : activeEffectsDefinitions)
 	{
 		Json::Value activeEffect;
+		activeEffect["name"] = activeEffectDefinition.name;
 		activeEffect["script"] = activeEffectDefinition.script;
 		activeEffect["priority"] = activeEffectDefinition.priority;
 		activeEffect["timeout"] = activeEffectDefinition.timeout;


### PR DESCRIPTION
Please be lenient with me, because this is the first pull request i had ever made.
I have added a name property in the Effect class to make it possible to get the name of the active effect in the 'serverinfo' JSON command results. I wouldn't name it a feature, it's more a bugfix, because without these changes, it isn't easily possible to get the current effect and compare it with a list of available effects.

Output before changes:
```
{   'info': {   'activeEffects': [   {   'args': {   'blobs': 5,
                                                     'color': [0, 255, 0],
                                                     'hueChange': 60.0,
                                                     'reverse': False,
                                                     'rotationTime': 60.0},
                                         'priority': 100,
                                         'script': '/root/hyperion/effects//mood-blobs.py',
                                         'timeout': 0}],
                'activeLedColor': [],
                'adjustment': [   {   'blueAdjust': [0, 0, 255],
                                      'greenAdjust': [0, 255, 0],
                                      'id': 'default',
...
```
Output after my changes:
```
{   'info': {   'activeEffects': [   {   'args': {   'blobs': 5,
                                                     'color': [0, 255, 0],
                                                     'hueChange': 60.0,
                                                     'reverse': False,
                                                     'rotationTime': 60.0},
                                         'name': 'Green mood blobs',
                                         'priority': 100,
                                         'script': '/root/hyperion/effects//mood-blobs.py',
                                         'timeout': 0}],
                'activeLedColor': [],
                'adjustment': [   {   'blueAdjust': [0, 0, 255],
                                      'greenAdjust': [0, 255, 0],
                                      'id': 'default',
...
```
Please note that the 'name' property of the active effect is now available in the JSON result of the 'serverinfo' command.
I think this fix was requested in this issue: #548 

