### PR TITLE
Fix RPI1 detection in installation script

### DIFF
--- a/bin/install_hyperion.sh
+++ b/bin/install_hyperion.sh
@@ -51,9 +51,9 @@ if [ $CPU_RPI -ne 1 ] && [ $CPU_IMX6 -ne 1 ] && [ $CPU_WETEK -ne 1 ] && [ $CPU_X
 fi
 
 #Check which RPi we are one (in case)
-RPI_1=`grep -m1 -c BCM2708 /proc/cpuinfo`
+RPI_1=`grep -m1 -c 'BCM2708\|BCM2835' /proc/cpuinfo`
 RPI_2=`grep -m1 -c BCM2709 /proc/cpuinfo`
-RPI_3=`grep -m1 -c 'BCM2710\|BCM2835' /proc/cpuinfo`
+RPI_3=`grep -m1 -c BCM2710 /proc/cpuinfo`
 
 #Check, if year equals 1970
 DATE=$(date +"%Y")


### PR DESCRIPTION
On my old Raspberry Pi1 B, cat /proc/cpuinfo gives :
> processor       : 0
> model name      : ARMv6-compatible processor rev 7 (v6l)
> BogoMIPS        : 697.95
> 
> Features        : half thumb fastmult vfp edsp java tls
> CPU implementer : 0x41
> CPU architecture: 7
> CPU variant     : 0x0
> CPU part        : 0xb76
> CPU revision    : 7
> 
> Hardware        : BCM2835
> Revision        : 000d
> Serial          : 0000000053cd43f1



