### PR TITLE
also kill 'hyperion-x11' processes

### DIFF
--- a/bin/install_hyperion.sh
+++ b/bin/install_hyperion.sh
@@ -81,6 +81,7 @@ SERVICEL="/usr/share/hyperion/services"
 echo '---> Stop Hyperion, if necessary'
 if [ $OS_OPENELEC -eq 1 ]; then
     killall hyperiond 2>/dev/null
+    killall hyperion-x11 2>/dev/null
 elif [ $USE_SYSTEMD -eq 1 ]; then
 	service hyperion stop 2>/dev/null
 	SERVICEP="/etc/systemd/system"

--- a/bin/remove_hyperion.sh
+++ b/bin/remove_hyperion.sh
@@ -58,6 +58,7 @@ SERVICEC=1
 echo '---> Stop Hyperion, if necessary'
 if [ $OS_OPENELEC -eq 1 ]; then
     killall hyperiond 2>/dev/null
+    killall hyperion-x11 2>/dev/null
 elif [ $USE_SYSTEMD -eq 1 ]; then
 	systemctl stop hyperion 2>/dev/null
 elif [ $USE_INITCTL -eq 1 ]; then


### PR DESCRIPTION
**1.** Tell us something about your changes.
On my target platform there are multiple hyperion-x11 processes and after a few restarts the led strip starts to flicker. The install and remove script should also kill these processes
**2.** If this changes affect the .conf file. Please provide the changed section
No changes in the .conf file
**3.** Reference a issue (optional)
No open issue for this change

