### PR TITLE
Fix broken videoMode setting (#429)

### DIFF
--- a/include/utils/VideoMode.h
+++ b/include/utils/VideoMode.h
@@ -16,7 +16,7 @@ enum VideoMode
 inline VideoMode parse3DMode(std::string videoMode)
 {
 	// convert to lower case
-	std::transform(videoMode.begin(), videoMode.end(), videoMode.begin(), ::tolower);
+	std::transform(videoMode.begin(), videoMode.end(), videoMode.begin(), ::toupper);
 
 	if (videoMode == "3DTAB")
 	{


### PR DESCRIPTION
Changing videoMode to 3DTAB or 3DSBS has no effect because user
provided value is forced to lower case but check is done in upper case

@see: https://github.com/hyperion-project/hyperion/issues/429